### PR TITLE
Use tini to start looker so zombies will be reaped

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     mysql-client \
     openjdk-11-jre \
     phantomjs \
+    tini \
     tzdata \
  && apt-get upgrade -y \
  && apt-get clean
@@ -32,7 +33,7 @@ ENV LOOKER_DIR /opt/looker
 
 # Minor version should be still valid or the build will failed, get the last
 # from the download page https://download.looker.com/
-ENV LOOKER_VERSION 7.18.33
+ENV LOOKER_VERSION 7.20.29
 
 RUN mkdir -p $HOME
 RUN mkdir -p $LOOKER_DIR
@@ -64,4 +65,4 @@ ENV PROTOCOL "https"
 
 USER looker
 
-CMD exec java $JAVAJVMARGS $JAVAARGS -jar $LOOKER_DIR/looker.jar start $LOOKERARGS $LOOKEREXTRAARGS
+CMD tini -- java $JAVAJVMARGS $JAVAARGS -jar $LOOKER_DIR/looker.jar start $LOOKERARGS $LOOKEREXTRAARGS

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -13,7 +13,7 @@ describe 'Dockerfile' do
     set :backend, :docker
     set :docker_image, "#{repository}/#{image}:#{tag}"
     set :docker_container_create_options,
-        'Entrypoint' => ['/bin/sh']
+        'Entrypoint' => ['tini', '--', '/bin/sh']
 
     if ENV.include?('DOCKER_HOST')
       set :docker_url, ENV['DOCKER_HOST']


### PR DESCRIPTION
## Context

Ajoute `tini` au conteneur pour lancer looker.

## Why

Looker génère des processus zombies qui ne se retrouvent ni gérés ni attachés à un process.
Tini résout ces cas.

## References

Voir jira INFRABUILD-1950
