### PR TITLE
[tini] Fix PID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,4 @@ ENV PROTOCOL "https"
 
 USER looker
 
-CMD tini -- java $JAVAJVMARGS $JAVAARGS -jar $LOOKER_DIR/looker.jar start $LOOKERARGS $LOOKEREXTRAARGS
+CMD exec tini -- java $JAVAJVMARGS $JAVAARGS -jar $LOOKER_DIR/looker.jar start $LOOKERARGS $LOOKEREXTRAARGS


### PR DESCRIPTION
## Context

Corrige:
```
[WARN  tini (6)] Tini is not running as PID 1 and isn't registered as a child subreaper.
Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1.


USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
looker       1  0.0  0.0   2612   544 ?        Ss   11:14   0:00 /bin/sh -c tini -- java $JAVAJVMARGS $JAVAARGS -jar $LOOKER_DIR/looker.jar start $LOOKERARGS $LOOKEREXTRAARGS
looker       6  0.0  0.0   2500   604 ?        S    11:14   0:00 tini -- java -XX:+UseG1GC -XX:MaxGCPauseMillis=2000 -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=70 -jar /opt/looker/looker.jar start --no-daemonize --log-format=json --no-log-to-file --shared-storage-dir=/data/ -d /home/looker/looker-db.yml
looker       7  137  1.4 14008536 1912804 ?    Sl   11:14   5:25  \_ java -XX:+UseG1GC -XX:MaxGCPauseMillis=2000 -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=70 -jar /opt/looker/looker.jar start --no-daemonize --log-format=json --no-log-to-file --shared-storage-dir=/data/ -d /home/looker/looker-db.yml
```

## References
https://honestica.atlassian.net/browse/INFRABUILD-1950 - `Process defunct dans le container looker en prodution`