### PR TITLE
[fix] Fix warning: "getprotobyname_r failed"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
     libc6-dev \
     libfontconfig1 \
     mysql-client \
+    netbase \
     openjdk-11-jre \
     phantomjs \
     tini \

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -26,4 +26,8 @@ describe 'Dockerfile' do
     its(:exit_status) { should eq 0 }
     its(:stdout) { should match(/chrome/i) }
   end
+
+  describe file('/etc/protocols') do
+    it { should exist }
+  end
 end


### PR DESCRIPTION
## Context

Fix the following error at looker startup:
```
Oct 14, 2021 8:52:25 AM jnr.netdb.NativeProtocolsDB load
WARNING: Failed to load native protocols db
java.lang.RuntimeException: getprotobyname_r failed
    at jnr.netdb.NativeProtocolsDB$LinuxNativeProtocolsDB.getProtocolByName(NativeProtocolsDB.java:180)
    at jnr.netdb.NativeProtocolsDB.load(NativeProtocolsDB.java:80)
    at jnr.netdb.NativeProtocolsDB.access$000(NativeProtocolsDB.java:40)
    at jnr.netdb.NativeProtocolsDB$SingletonHolder.<clinit>(NativeProtocolsDB.java:47)
    at jnr.netdb.NativeProtocolsDB.getInstance(NativeProtocolsDB.java:43)
    at jnr.netdb.Protocol$ProtocolDBSingletonHolder.load(Protocol.java:107)
    at jnr.netdb.Protocol$ProtocolDBSingletonHolder.<clinit>(Protocol.java:103)
    at jnr.netdb.Protocol.getProtocolDB(Protocol.java:96)
    at jnr.netdb.Protocol.getProtocolByNumber(Protocol.java:59)
    at org.jruby.ext.socket.Addrinfo.<init>(Addrinfo.java:787)
    at org.jruby.ext.socket.SocketUtils.ip_address_list(SocketUtils.java:433)
    at org.jruby.ext.socket.RubySocket.ip_address_list(RubySocket.java:346)
    at org.jruby.ext.socket.RubySocket$INVOKER$s$0$0$ip_address_list.call(RubySocket$INVOKER$s$0$0$ip_address_list.gen)
[...]
```