### PR TITLE
[chrome] Do not use zygote

### DIFF
--- a/chromium
+++ b/chromium
@@ -1,4 +1,4 @@
 #!/bin/bash
 export HOME=/home/looker
 export DBUS_SESSION_BUS_ADDRESS=/dev/null
-exec /opt/chrome-linux/chrome --no-sandbox $@
+exec /opt/chrome-linux/chrome --no-sandbox --allow-insecure-localhost --no-zygote $@


### PR DESCRIPTION
## Context
Try to solve:
```
[0412/110533.328618:ERROR:zygote_host_impl_linux.cc(273)] Failed to adjust OOM score of renderer with pid 1140: Permission denied (13)
[0412/110533.442984:ERROR:zygote_host_impl_linux.cc(273)] Failed to adjust OOM score of renderer with pid 1162: Permission denied (13)
```

> Disables the use of a zygote process for forking child processes. Instead, child processes will be forked and exec'd directly. Note that --no-sandbox should also be used together with this flag because the sandbox needs the zygote to work. [↪](https://source.chromium.org/chromium/chromium/src/+/main:content/public/common/content_switches.cc?q=kNoZygote&ss=chromium)