### PR TITLE
[chrome] Ignore ssl errors for localhost

### DIFF
--- a/chromium
+++ b/chromium
@@ -1,3 +1,3 @@
 #!/bin/bash
 export HOME=/home/looker
-exec /opt/chrome-linux/chrome --no-sandbox $@
+exec /opt/chrome-linux/chrome --no-sandbox --allow-insecure-localhost $@


### PR DESCRIPTION
## Context

Try to solve:
```
[0412/110533.459710:ERROR:cert_verify_proc_builtin.cc(676)] CertVerifyProcBuiltin for localhost failed:
----- Certificate i=0 (CN=self-signed.looker.com) -----
ERROR: No matching issuer found


[0412/110533.460246:ERROR:ssl_client_socket_impl.cc(985)] handshake failed; returned -1, SSL error code 1, net_error -202
[0412/110534.277759:ERROR:ssl_client_socket_impl.cc(985)] handshake failed; returned -1, SSL error code 1, net_error -202
[0412/110534.297979:ERROR:ssl_client_socket_impl.cc(985)] handshake failed; returned -1, SSL error code 1, net_error -202
```

> Enables TLS/SSL errors on localhost to be ignored (no interstitial, no blocking of requests). [↪](https://source.chromium.org/chromium/chromium/src/+/main:content/public/common/content_switches.cc?q=kAllowInsecureLocalhost&ss=chromium)