### PR TITLE
[chrome] Rollback to initial exact release 96

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,10 +75,13 @@ RUN apt-get update \
     xkb-data \
  && apt-get clean
 
-# https://www.chromium.org/getting-involved/download-chromium/
-RUN curl -Ss "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F960973%2Fchrome-linux.zip?generation=1642609777247754&alt=media" -o /tmp/chrome.zip \
- && unzip /tmp/chrome.zip -d /opt \
- && rm /tmp/chrome.zip
+ENV CHROME_VERSION 96.0.4664.110-1
+RUN curl -Ss https://dl.google.com/linux/linux_signing_key.pub > /etc/apt/trusted.gpg.d/google-chrome.asc \
+ && echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list \
+ && apt-get update \
+ && curl -Ss https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb -o /tmp/chrome.deb \
+ && apt install --yes --no-install-recommends /tmp/chrome.deb \
+ && apt-get clean
 
 COPY chromium /usr/bin
 RUN chmod +x /usr/bin/chromium

--- a/chromium
+++ b/chromium
@@ -1,4 +1,3 @@
 #!/bin/bash
 export HOME=/home/looker
-export DBUS_SESSION_BUS_ADDRESS=/dev/null
-exec /opt/chrome-linux/chrome --no-sandbox --allow-insecure-localhost --no-zygote $@
+exec google-chrome --no-sandbox $@

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -41,7 +41,7 @@ describe 'Dockerfile' do
   # https://community.looker.com/general-looker-administration-35/troubleshooting-common-chromium-errors-20621
   describe command('chromium --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/chrom.* 99\.0\./i) }
+    its(:stdout) { should match(/chrom.* 96\.0\./i) }
   end
 
   describe command('chromium --headless --disable-gpu --print-to-pdf /srv/page.html') do


### PR DESCRIPTION
## Context
Rollback à la version exacte que nous utilisions avant les tentatives d'upgrade.
