### PR TITLE
[chrome] Upgrade to 97

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN apt-get update \
     xkb-data \
  && apt-get clean
 
-ENV CHROME_VERSION 96.0.4664.110-1
+ENV CHROME_VERSION 97.0.4692.99-1
 RUN curl -Ss https://dl.google.com/linux/linux_signing_key.pub > /etc/apt/trusted.gpg.d/google-chrome.asc \
  && echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list \
  && apt-get update \

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -46,7 +46,7 @@ describe 'Dockerfile' do
   # https://community.looker.com/general-looker-administration-35/troubleshooting-common-chromium-errors-20621
   describe command('chromium --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/chrom.* 96\.0\./i) }
+    its(:stdout) { should match(/chrom.* 97\.0\./i) }
   end
 
   describe command('chromium --headless --disable-gpu --print-to-pdf /srv/page.html') do


### PR DESCRIPTION
## Context
Mise à jour vers chrome 97, la doc :gb: recommande précisément cette version (contrairement à la version :fr: :trollface:).

![Capture d’écran du 2023-04-14 16-35-44](https://user-images.githubusercontent.com/2512238/232074616-59f2ec04-9239-46ac-bb41-6c786b50cb29.png)

VS:

![image (7)](https://user-images.githubusercontent.com/2512238/232074643-f3f231ee-e2fb-48f3-a063-caa0b79dc7cd.png)
