### PR TITLE
[chrome] Rollback to version 97

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN apt-get update \
     xkb-data \
  && apt-get clean
 
-ENV CHROME_VERSION 113.0.5672.126-1
+ENV CHROME_VERSION 97.0.4692.99-1
 RUN curl -Ss https://dl.google.com/linux/linux_signing_key.pub > /etc/apt/trusted.gpg.d/google-chrome.asc \
  && echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list \
  && apt-get update \

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -46,7 +46,7 @@ describe 'Dockerfile' do
   # https://community.looker.com/general-looker-administration-35/troubleshooting-common-chromium-errors-20621
   describe command('chromium --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/chrom.* 113\./i) }
+    its(:stdout) { should match(/chrom.* 97\./i) }
   end
 
   describe command('chromium --headless --disable-gpu --print-to-pdf /srv/page.html') do


### PR DESCRIPTION
## Context
Rollback à la version 97, afin de fix:
```
Failed to navigate to https://localhost:9999/dashboards/186?longTables=false&pdf_landscape=false&pdf_paper_size=fitPageToDashboard&print_mode=true&Date+d%27envoi=30+day&Type+de+connecteur+pour+l%27envoi=DPI&Groupe=&Etablissement=&Granularit%C3%A9+de+date=Jour&Type+de+connecteur+pour+la+recherche=DPI%2CPMSI&ID=not+34&FlowtypeV2=%22INTEGRATION_REQUEST%22&print_mode=true&run=1&layout=print - retried
```

## References
https://honestica.atlassian.net/browse/INFRAOPS-4708 - `[looker] Upgrade to 23.10 and chrome 113`