### PR TITLE
[chrome] Dirty fix to get version 97

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 20.10.12
+      - run: docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
       - run: make build email=$EMAIL license=$LICENSE version=<< pipeline.parameters.looker-version >>
       - run: make setup
       - run: make test email=$EMAIL license=$LICENSE version=<< pipeline.parameters.looker-version >>

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,11 +75,12 @@ RUN apt-get update \
     xkb-data \
  && apt-get clean
 
-ENV CHROME_VERSION 113.0.5672.126-1
+ENV CHROME_VERSION 97.0.4692.99-1
+# Dirty fix due to unavailability of the upper chrome version
+COPY --from=honestica/looker:23.6.77-efe426d1f137a8931288ed547cdf89a3a5c13008 /tmp/chrome.deb /tmp/chrome.deb
 RUN curl -Ss https://dl.google.com/linux/linux_signing_key.pub > /etc/apt/trusted.gpg.d/google-chrome.asc \
  && echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list \
- && apt-get update \
- && curl -Ss https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb -o /tmp/chrome.deb
+ && apt-get update
 RUN apt install --yes --no-install-recommends /tmp/chrome.deb \
  && apt-get clean
 

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -46,7 +46,7 @@ describe 'Dockerfile' do
   # https://community.looker.com/general-looker-administration-35/troubleshooting-common-chromium-errors-20621
   describe command('chromium --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/chrom.* 113\./i) }
+    its(:stdout) { should match(/chrom.* 97\./i) }
   end
 
   describe command('chromium --headless --disable-gpu --print-to-pdf /srv/page.html') do


### PR DESCRIPTION
## Context
Fix très moche pour récupérer la version 97 de chrome.

Je suis en train d'investiguer pour utiliser directement dbus, ça s'avère néanmoins plus compliqué qu'espéré.
J'ai setup complètement looker staging où je reproduis le problème.

Afin de débloquer la production je propose temporairement ce fix.
