### PR TITLE
Fix jruby error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,12 @@ setup: ## Install local requirement to work on this image
 
 .PHONY: sh
 sh: ## Get a shell on given image | make sh version=20.20 [repository=honestica] [image=looker]
-	@docker run --rm --read-only --mount 'type=tmpfs,dst=/home/looker' --mount 'type=tmpfs,dst=/tmp' -it -v $(PWD):/srv --entrypoint /bin/bash $(repository)/$(image):$(shell scripts/full_version --version $(version) --email $(email) --license $(license))
+	docker volume create --name looker-test
+	@docker run --rm -it --read-only -w /home/looker --mount 'type=tmpfs,dst=/tmp' -v looker-test:/home/looker:rw -v $(PWD):/srv --entrypoint /bin/bash $(repository)/$(image):$(shell scripts/full_version --version $(version) --email $(email) --license $(license))
 
 .PHONY: test
 test: ## Run tests on given image | make test version=22.20 [repository=] [image=]
+	docker volume create --name looker-test
 	@REPOSITORY=$(repository) IMAGE=$(image) TAG=$(shell scripts/full_version --version $(version) --email $(email) --license $(license)) rspec -c spec
 
 .PHONY: test-hadolint


### PR DESCRIPTION
## Context

Fix:
```yaml
ERROR:
  org.jruby.embed.EvalFailedException:
    (LoadError) bad SnakeYAML version 2.0,
    required 1.21 or higher;
    check your CLASSPATH for a conflicting jar
```

`jmx_prometheus_javaagent` veut `SnakeYAML` en version `2.0`, looker veut `SnakeYAML` `1.21 < 2.0`.
Tant que `looker` ne met pas à jour sa dépendance on sera bloqué à `jmx_prometheus_javaagent` dans sa version `0.17.2`.

En conséquence je l'installe mais le désactive des envvars, ce sera une option du chart pour l'activer.

J'en profite pour ajouter un test, ce soucis aurait dû être catché par la CI lors de ma [PR précédente](https://github.com/honestica/docker-looker/pull/56).

## References

https://github.com/honestica/docker-looker/pull/56