### PR TITLE
[CI] Fix "Job was rejected because this version of Docker is not supported on this resource class"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 24
+          version: docker24
       - run: docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
       - run: make build email=$EMAIL license=$LICENSE version=<< pipeline.parameters.looker-version >>
       - run: make setup
@@ -40,7 +40,7 @@ jobs:
       - run: make download email=$EMAIL license=$LICENSE version=<< pipeline.parameters.looker-version >>
       - bot/docker-build-and-push:
           applicationName: looker
-          dockerEngineVersion: "24"
+          dockerEngineVersion: docker24
           dockerBuildOptions: --build-arg EMAIL=$EMAIL --build-arg LICENSE=$LICENSE --build-arg LOOKER_VERSION=$LOOKER_VERSION
           dockerTag: $LOOKER_VERSION-$CIRCLE_SHA1
 


### PR DESCRIPTION
## Context
Fix for:
```
Job was rejected because this version of Docker is not supported on this resource class.
Try removing the version of Docker in your .circleci/config.yml and re-running
```