### PR TITLE
[dockerfile] Bump 'looker' to v25.6 + docker image 'noble-20250404'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 parameters:
   looker-version:
     type: string
-    default: "25.0"
+    default: "25.6"
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble-20241118.1
+FROM ubuntu:noble-20250404
 
 RUN apt-get update \
  && DEBIAN_FRONTEND="noninteractive" apt-get -y install --no-install-recommends \


### PR DESCRIPTION
## Context

We would like to bump `looker` from v25.0 to v25.6 We also bump `ubuntu` from `noble-20241118.1` to `noble-20250404`

## References

https://cloud.google.com/looker/docs/release-notes#April_09_2025
