### PR TITLE
[circleci][sast] Add filters param for 'sast_scan' job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,4 +74,7 @@ workflows:
     jobs:
       - bot/sast:
           context: org-global
-
+          filters:
+            branches:
+              ignore:
+                - master


### PR DESCRIPTION
Follow this doc:
* https://www.notion.so/lifen/Static-Application-Security-Testing-SAST-934b0ed91abc4158b94e034fd51ac23e

We add a filter on `sast_scan` CircleCI's job
