### PR TITLE
[dependabot] Remove useless reviewers param

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,3 @@ updates:
     time: "02:00"
     timezone: Europe/Paris
   target-branch: master
-  reviewers:
-  - marcmillien
-  - mtparet


### PR DESCRIPTION
## Context

Follow this doc:
* https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Option related to reviewers is useless, and we should only use `codeowners` config file
