### PR TITLE
[github][dependabot] Fix directory config follow a previous change

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,7 +2,7 @@ version: 2
 
 updates:
 - package-ecosystem: docker
-  directory: "/"
+  directory: "/docker"
   schedule:
     interval: weekly
     day: sunday


### PR DESCRIPTION
## Context

Fix about this PR:
* https://github.com/honestica/docker-looker/pull/101

We also need to adapt the `directory` param to allow `dependabot` to work again
Indeed, on the previous commit, we move all `docker` config into the `docker/` folder

Sources:
* https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--
* https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml#L64-L68
