### PR TITLE
[circleci][config] Remove 'pre-steps' related to 'check-changed-files-or-halt'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,6 @@ workflows:
           context: org-global
       - build-and-push:
           context: org-global
-          pre-steps:
-            - checkout
-            - bot/check-changed-files-or-halt:
-                pattern: 'docker/'
           requires:
             - test
           filters:


### PR DESCRIPTION
## Context

We temporary remove the `pre-steps` related to
`check-changed-files-or-halt`

Indeed, we need to adjust our check about this job, because the docker build will run when the PR is merged
The `check-changed-files-or-halt` step will check all changes which is made between `master` branch vs. our current branch => so it will not work for `build-and-push` step

## References

Fix about this PR:
* https://github.com/honestica/docker-looker/pull/101
