### PR TITLE
[circleci][config] Fix path about docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
       - bot/docker-build-and-push:
           applicationName: looker
           dockerEngineVersion: docker24
+          dockerfilePath: docker/
           dockerBuildOptions: --build-arg EMAIL=$EMAIL --build-arg LICENSE=$LICENSE --build-arg LOOKER_VERSION=$LOOKER_VERSION
           dockerTag: $LOOKER_VERSION-$CIRCLE_SHA1
 


### PR DESCRIPTION
## Context

Follow this PR:
* https://github.com/honestica/docker-looker/pull/101

This is a fix to target the right `Dockerfile` directory for `docker-build-and-push` step
We add the `dockerfilePath` param for this purpose

This is to avoid this kind of error:
```
...
Login Succeeded
awk: cannot open ./Dockerfile (No such file or directory)

Exited with code exit status 2
```
