### PR TITLE
[circleci][config] Add pre-requisite to build docker image only for specific changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,26 @@ parameters:
     type: string
     default: "26.2"
 
+commands:
+  check-changed-files-or-halt:
+    parameters:
+      pattern:
+        type: string
+      revision:
+        type: string
+        default: master
+    steps:
+      - run: git show << parameters.revision >>..HEAD --name-only --pretty="" | egrep '<< parameters.pattern >>' || circleci-agent step halt
+
 jobs:
   test:
     docker:
       - image: cimg/ruby:3.0
     steps:
       - checkout
+      - check-changed-files-or-halt:
+          pattern: docker/
+          revision: 'HEAD^'
       - setup_remote_docker:
           docker_layer_caching: true
           version: docker24
@@ -52,6 +66,11 @@ workflows:
           context: org-global
       - build-and-push:
           context: org-global
+          pre-steps:
+            - checkout
+            - check-changed-files-or-halt:
+                pattern: docker/
+                revision: 'HEAD^'
           requires:
             - test
           filters:


### PR DESCRIPTION
## Context

We would like to build + push a docker image only if there is a change on the `docker/` folder

We use the `check-changed-files-or-halt` command for this purpose
We also use `HEAD^` keyword to be able to retrieve all commits related to a merge commit
