### PR TITLE
[circleci][config] Fix patterns param about 'check-multiple-changed-files-or-halt' job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - checkout
       - bot/check-multiple-changed-files-or-halt:
-          patterns: "docker/"
+          patterns: ".circleci/config.yml,docker/"
       - setup_remote_docker:
           docker_layer_caching: true
           version: docker24
@@ -57,7 +57,7 @@ workflows:
           pre-steps:
             - checkout
             - bot/check-multiple-changed-files-or-halt:
-                patterns: "docker/"
+                patterns: ".circleci/config.yml,docker/"
           requires:
             - test
           filters:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -Ss --location -o- https://bitbucket.org/ariya/phantomjs/downloads/phan
  && mv /tmp/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64/bin/phantomjs /usr/bin \
  && chmod +x /usr/bin/phantomjs
 
-ENV MAVEN_VERSION 3.9.14
+ENV MAVEN_VERSION 3.9.15
 RUN curl -Ss --location -o- https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | tar -C /opt --no-same-permissions -xz \
  && ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/bin/mvn
 


### PR DESCRIPTION
## Context

Fix about this PR:
* https://github.com/honestica/docker-looker/pull/120

My bad, I forgot that we are bumping `looker` version through the `.circleci/config.yml` file

Fix the `patterns` param, adding `.circleci/config.yml` file

Also bump `maven` to the last version (ie 3.9.15)
Source:
* https://maven.apache.org/download.cgi#apache-maven-3-9-15

This is to avoid any error when trying to build the docker image:
```
------
 > [ 4/21] RUN curl -Ss --location -o- https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz | tar -C /opt --no-same-permissions -xz  && ln -s /opt/apache-maven-3.9.14/bin/mvn /usr/bin/mvn:
0.353 
0.353 gzip: stdin: not in gzip format
0.354 tar: Child returned status 1
0.354 tar: Error is not recoverable: exiting now
...
```

Source:
* https://app.circleci.com/pipelines/github/honestica/docker-looker/656/workflows/39fb3491-00ef-45b1-84d5-1ab6fae330df/jobs/825
